### PR TITLE
ノート作成機能実装

### DIFF
--- a/src/components/NoteBody.vue
+++ b/src/components/NoteBody.vue
@@ -1,21 +1,118 @@
 <template>
-  <div>
-    <div v-html="compiledHTML"></div>
+<div>
+  <div class="page-NoteEdit-body">
+    <textarea :value="note.body" />
   </div>
+  <div class="page-NoteEdit-preview">
+    <div class="NoteBody" v-html="compiledHTML"></div>
+  </div>
+</div>
 </template>
 <script>
 import marked from 'marked'
 export default {
   name: 'notebody',
   props: {
-    body: String
+    note: Object
   },
   computed: {
     compiledHTML () {
-      if (this.body !== undefined) {
-        return marked(this.body)
+      if (this.note.body !== undefined) {
+        return marked(this.note.body)
       }
     }
   }
 }
 </script>
+<style>
+.page-NoteEdit {
+  display: flex;
+  flex-direction: column;
+  height: calc(100vh - 45px);
+  overflow: hidden;
+}
+
+.page-NoteEdit-header {
+  position: relative;
+  border-bottom: 1px solid #CCC;
+  padding: 5px;
+  height: 50px;
+  box-sizing: border-box;
+}
+
+.page-NoteEdit-header > input[type="text"] {
+  font-size: 24px;
+  padding: 5px;
+  border: none;
+  font-weight: bold;
+  width: calc(100% - 200px);
+  outline: none;
+}
+
+.page-NoteEdit-buttons {
+  position: absolute;
+  right: 0;
+  top: 10px;
+}
+
+.page-NoteEdit-buttons > .Button {
+  margin: 0 5px;
+}
+
+.page-NoteEdit-body {
+  border-bottom: 1px solid #CCC;
+}
+
+.page-NoteEdit-body textarea {
+  width: 100%;
+  font-size: 16px;
+  box-sizing: border-box;
+  border: none;
+  outline: none;
+  padding: 10px;
+  resize: vertical;
+  height: 260px;
+  max-height: calc(100vh - 45px - 50px);
+  display: block;
+}
+
+.page-NoteEdit-preview {
+  flex: 1 1 auto;
+  overflow: auto;
+  padding: 20px 10px 10px 10px;
+  position: relative;
+}
+
+.page-NoteEdit-preview:before {
+  content: 'Preview';
+  display: inline-block;
+  background-color: #F5F5F5;
+  position: absolute;
+  top: 0;
+  left: 0;
+  padding: 5px 10px;
+  font-size: 12px;
+  border-right: 1px solid #CCC;
+  border-bottom: 1px solid #CCC;
+}
+.NoteBody pre {
+  border: 1px solid #CCC;
+  padding: 10px;
+  background: #FAFAFA;
+  margin: 10px 0;
+}
+
+.NoteBody blockquote {
+  border-left: 5px solid #CCC;
+  padding: 10px 10px 10px 20px;
+}
+
+.NoteBody blockquote > *:first-child {
+  margin-top: 0;
+}
+
+.NoteBody blockquote > *:last-child {
+  margin-bottom: 0;
+}
+</style>
+

--- a/src/components/NoteBody.vue
+++ b/src/components/NoteBody.vue
@@ -1,7 +1,7 @@
 <template>
 <div>
   <div class="page-NoteEdit-body">
-    <textarea :value="note.body" />
+    <textarea v-model="note.body" />
   </div>
   <div class="page-NoteEdit-preview">
     <div class="NoteBody" v-html="compiledHTML"></div>
@@ -115,4 +115,3 @@ export default {
   margin-bottom: 0;
 }
 </style>
-

--- a/src/components/NoteBody.vue
+++ b/src/components/NoteBody.vue
@@ -1,7 +1,7 @@
 <template>
 <div>
   <div class="page-NoteEdit-body">
-    <textarea v-model="note.body" />
+    <textarea v-model="note.body" @change="updateNote" />
   </div>
   <div class="page-NoteEdit-preview">
     <div class="NoteBody" v-html="compiledHTML"></div>
@@ -14,6 +14,11 @@ export default {
   name: 'notebody',
   props: {
     note: Object
+  },
+  methods: {
+    updateNote: function () {
+      this.$store.dispatch('updateNote', this.note)
+    }
   },
   computed: {
     compiledHTML () {

--- a/src/components/NoteHeader.vue
+++ b/src/components/NoteHeader.vue
@@ -1,0 +1,48 @@
+<template>
+<div class="page-NoteEdit-header">
+  <input aria-label="タイトル" ref="title" type="text" :value="note.title" data-page-title />
+    <div class="page-NoteEdit-buttons">
+    </div>
+</div>
+</template>
+
+<script>
+export default {
+  name: 'noteheader',
+  props: {
+    note: Object
+  }
+}
+</script>
+
+<style>
+.page-NoteEdit {
+  display: flex;
+  flex-direction: column;
+  height: calc(100vh - 45px);
+  overflow: hidden;
+}
+
+.page-NoteEdit-header {
+  position: relative;
+  border-bottom: 1px solid #CCC;
+  padding: 5px;
+  height: 50px;
+  box-sizing: border-box;
+}
+
+.page-NoteEdit-header > input[type="text"] {
+  font-size: 24px;
+  padding: 5px;
+  border: none;
+  font-weight: bold;
+  width: calc(100% - 200px);
+  outline: none;
+}
+
+.page-NoteEdit-buttons {
+  position: absolute;
+  right: 0;
+  top: 10px;
+}
+</style>

--- a/src/components/NoteHeader.vue
+++ b/src/components/NoteHeader.vue
@@ -1,16 +1,33 @@
 <template>
 <div class="page-NoteEdit-header">
-  <input aria-label="タイトル" ref="title" type="text" :value="note.title" data-page-title />
+  <input aria-label="タイトル" ref="title" type="text" v-model="note.title" data-page-title />
     <div class="page-NoteEdit-buttons">
+      <ButtonElement :button-label="label" :onClick="save" />
     </div>
 </div>
 </template>
 
 <script>
+import ButtonElement from '@/components/ButtonElement'
+import store from '@/stores/main'
 export default {
   name: 'noteheader',
+  store,
+  components: {
+    ButtonElement
+  },
   props: {
     note: Object
+  },
+  data: function () {
+    return {
+      label: 'ノート保存'
+    }
+  },
+  methods: {
+    save () {
+      this.$store.dispatch('updateNote', this.note)
+    }
   }
 }
 </script>

--- a/src/components/NoteList.vue
+++ b/src/components/NoteList.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <div class="NoteList">
-      <ul v-for="note in notes" :key="note.id">
+      <ul v-for="note in notes" :key="note.id + '-note'">
         <li class="NoteList-item" @click="select(note)">
           <router-link :to="{ path: `/notes/${note.id}/edit` }">
             <span class="NoteList-title">{{ note.title }}</span>

--- a/src/pages/App.vue
+++ b/src/pages/App.vue
@@ -26,7 +26,6 @@ export default {
   font-family: 'Avenir', Helvetica, Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  text-align: center;
   color: #2c3e50;
 }
 .page-App-main {

--- a/src/pages/Dashboard.vue
+++ b/src/pages/Dashboard.vue
@@ -8,14 +8,19 @@
         <NoteList :notes="notes"></NoteList>
       </div>
     </div>
-    <div v-show="currentNote.body" class="page-Dashboard-main" role="form">
-      <NoteBody :body="currentNote.body"></NoteBody>
+    <div v-show="currentNote" class="page-Dashboard-main" role="form">
+      <div class="page-NoteEdit">
+        <NoteHeader :note="currentNote"></NoteHeader>
+
+        <NoteBody :note="currentNote"></NoteBody>
+      </div>
     </div>
   </div>
 </template>
 <script>
 import ButtonElement from '@/components/ButtonElement'
 import NoteList from '@/components/NoteList'
+import NoteHeader from '@/components/NoteHeader'
 import NoteBody from '@/components/NoteBody'
 import store from '@/stores/main'
 
@@ -25,7 +30,8 @@ export default {
   components: {
     ButtonElement,
     NoteList,
-    NoteBody
+    NoteBody,
+    NoteHeader
   },
   methods: {
     alertCheck () {

--- a/src/services/data.js
+++ b/src/services/data.js
@@ -17,7 +17,7 @@ module.exports = [
     'id': 2,
     'title': 'GraphQLでNonNullなList',
     'updated': '2016-04-24 12:32:50',
-    'body': '```javascript\nclass FooError extends Error {}\nconsole.log(new FooError() instanceof FooError); //=> false\nconsole.log(new FooError() instanceof Error); //=> true\n\nclass SampleArray extends Array {}\nconsole.log(new SampleArray() instanceof SampleArray); //=> false\nconsole.log(new SampleArray() instanceof Array);```',
+    'body': '```javascript\nclass Sample ```こんな感じで文章かく',
     'user': 'MyUserName'
   },
   {

--- a/src/stores/main.js
+++ b/src/stores/main.js
@@ -32,7 +32,18 @@ export default new Vuex.Store({
       context.commit('initNotes', notes)
     },
     addToNote (context, label) {
-      alert('store dispatch' + label)
+      const d = new Date()
+      const updated = `${d.getFullYear()}-${d.getMonth() + 1}-${d.getDate()} ${d.toTimeString().split(' ')[0]}`
+      const id = this.state.notes.length + 1
+      const note = {
+        id: id,
+        title: 'Untitled',
+        body: '',
+        user: 'MyUserName',
+        updated: updated
+      }
+      this.state.notes.unshift(note)
+      context.commit('addToNote', note)
     },
     selectNote (context, note) {
       context.commit('selectNote', note)

--- a/src/stores/main.js
+++ b/src/stores/main.js
@@ -10,14 +10,14 @@ export default new Vuex.Store({
   },
   getters: {
     initialNotes: state => {
-      state.currentProduct = state.notes[0]
+      state.currentstate = state.notes[0]
       return state.notes
     }
   },
   mutations: {
     initNotes (state, notes) {
-      notes.forEach(function (product, index, array) {
-        state.notes.push(product)
+      notes.forEach(function (_note, index, array) {
+        state.notes.push(_note)
       })
     },
     addToNote (state, note) {
@@ -25,6 +25,14 @@ export default new Vuex.Store({
     },
     selectNote (state, note) {
       state.note = note
+    },
+    updateNote (state, note) {
+      state.notes.forEach(function (_note, index, array) {
+        if (_note.id === note.id) {
+          _note = note
+          state.note = note
+        }
+      })
     }
   },
   actions: {
@@ -47,6 +55,9 @@ export default new Vuex.Store({
     },
     selectNote (context, note) {
       context.commit('selectNote', note)
+    },
+    updateNote (context, note) {
+      context.commit('updateNote', note)
     }
   }
 })


### PR DESCRIPTION
※ 以下の変更点の対応が終わったらWIP外す

## このPRについて

issue #1 対応

## 変更点

- [x] 一覧画面にあるノート作成ボタンをクリックすると、左側のナビバーにuntiltledと作成日の時間帯で値が追加される
- [x] 該当のuntiledのノートをクリックすると、/notes/:id/editのURLに遷移して編集可能な状態になる

## 動作確認


ノート作成時の処理
![2018-03-12 19 00 48](https://user-images.githubusercontent.com/950924/37277359-ccdafce2-2627-11e8-8ed9-8c2c73e195d4.png)


![2018-03-13-note](https://user-images.githubusercontent.com/950924/37311079-61136cee-2689-11e8-959d-c27b94fb5e19.gif)
